### PR TITLE
fix(Karma-Typescript): Explicitly exclude typings module

### DIFF
--- a/.config/config.ts
+++ b/.config/config.ts
@@ -9,6 +9,14 @@ export const preprocessors = {
   "**/*.ts": ["karma-typescript"],
 };
 
+export const karmaTypescriptConfig = { 
+  bundlerOptions: {
+    exclude: [
+      "@ideal-postcodes/api-typings"
+    ]
+  }
+}
+
 export const files = [{ pattern: "lib/**/*.ts" }, { pattern: "test/**/*.ts" }];
 
 export const reporters = ["dots", "karma-typescript"];

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -1,5 +1,5 @@
 import { HttpResponse } from "./agent";
-import { ApiErrorResponse } from "../node_modules/@ideal-postcodes/api-typings";
+import { ApiErrorResponse } from "@ideal-postcodes/api-typings";
 
 /**
  * IdealPostcodesErrorOptions

--- a/lib/resources/addresses.ts
+++ b/lib/resources/addresses.ts
@@ -1,5 +1,5 @@
 import { listMethod } from "./resource";
-import { AddressQueryResponse } from "../../node_modules/@ideal-postcodes/api-typings";
+import { AddressQueryResponse } from "@ideal-postcodes/api-typings";
 import { OptionalStringMap } from "../util";
 import { Client } from "../client";
 import { HttpResponse } from "../agent";

--- a/lib/resources/autocomplete.ts
+++ b/lib/resources/autocomplete.ts
@@ -1,5 +1,5 @@
 import { listMethod } from "./resource";
-import { AddressSuggestionResponse } from "../../node_modules/@ideal-postcodes/api-typings";
+import { AddressSuggestionResponse } from "@ideal-postcodes/api-typings";
 import { OptionalStringMap } from "../util";
 import { Client } from "../client";
 import { HttpResponse } from "../agent";

--- a/lib/resources/keys.ts
+++ b/lib/resources/keys.ts
@@ -3,7 +3,7 @@ import {
   PublicKeyResponse,
   PrivateKeyResponse,
   KeyUsageResponse,
-} from "../../node_modules/@ideal-postcodes/api-typings";
+} from "@ideal-postcodes/api-typings";
 import { OptionalStringMap } from "../util";
 import { Client } from "../client";
 import { HttpResponse } from "../agent";

--- a/lib/resources/postcodes.ts
+++ b/lib/resources/postcodes.ts
@@ -1,5 +1,5 @@
 import { retrieveMethod } from "./resource";
-import { PostcodesResponse } from "../../node_modules/@ideal-postcodes/api-typings";
+import { PostcodesResponse } from "@ideal-postcodes/api-typings";
 import { OptionalStringMap } from "../util";
 import { Client } from "../client";
 import { HttpResponse } from "../agent";

--- a/lib/resources/udprn.ts
+++ b/lib/resources/udprn.ts
@@ -1,5 +1,5 @@
 import { retrieveMethod } from "./resource";
-import { UdprnResponse } from "../../node_modules/@ideal-postcodes/api-typings";
+import { UdprnResponse } from "@ideal-postcodes/api-typings";
 import { OptionalStringMap } from "../util";
 import { Client } from "../client";
 import { HttpResponse } from "../agent";

--- a/lib/resources/umprn.ts
+++ b/lib/resources/umprn.ts
@@ -1,5 +1,5 @@
 import { retrieveMethod } from "./resource";
-import { UmprnResponse } from "../../node_modules/@ideal-postcodes/api-typings";
+import { UmprnResponse } from "@ideal-postcodes/api-typings";
 import { OptionalStringMap } from "../util";
 import { Client } from "../client";
 import { HttpResponse } from "../agent";


### PR DESCRIPTION
Fixing this in Karma-Typescript (i.e. excluding typings only module)
does not seem realistic